### PR TITLE
add filter post_selection_ui_render_results_args to allow for filtering 

### DIFF
--- a/post-selection-ui.php
+++ b/post-selection-ui.php
@@ -180,6 +180,7 @@ class Post_Selection_Box {
 		}
 
 		$query_args = wp_parse_args($args, $defaults);
+		$query_args = apply_filters( 'psu_modify_query_args', $query_args, $this->name );		
 		return new WP_Query($query_args);
 	}
 


### PR DESCRIPTION
If I wanted to, for example, only allow parents to be connected (this example would be using this module with o2o), this filter would allow this via:

```
add_filter('post_selection_ui_render_results_args', function( $query ){
    $query['post_parent'] = 0;
    return $query;
});
```
