### PR TITLE
WordPress 3.9+ compatibility in widgets admin

### DIFF
--- a/post-selection-ui.js
+++ b/post-selection-ui.js
@@ -288,6 +288,14 @@
 		$('.psu-box').post_selection_ui();
 	}
 
+	function initPostSelectionUIOnEvent( e, widget ) {
+
+		$psu = widget.find( '.psu-box' );
+
+		$psu.length && $psu.post_selection_ui();
+
+	}
+
 	//work around for first creation of widget
 	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.fixLabels ) ) {
 
@@ -298,18 +306,12 @@
 			if(typeof console != 'undefined'){
 				console.log(widget);
 			}
-			widget.find('.psu-box').post_selection_ui();
+			initPostSelectionUIOnEvent( null, widget );
 		};
 
 	} else  {
 
-		$( document ).on( 'widget-added', function( e, $widget ) {
-
-			$psu = $widget.find( '.psu-box' );
-
-			$psu.length && $psu.post_selection_ui();
-
-		} );
+		$( document ).on( 'widget-added widget-updated', initPostSelectionUIOnEvent );
 
 	}
 

--- a/post-selection-ui.js
+++ b/post-selection-ui.js
@@ -289,7 +289,8 @@
 	}
 
 	//work around for first creation of widget
-	if(typeof(wpWidgets) === 'object') {
+	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.fixLabels ) ) {
+
 		var oldSave = __bind(wpWidgets, wpWidgets.fixLabels);
 
 		wpWidgets.fixLabels = function(widget) {
@@ -299,5 +300,17 @@
 			}
 			widget.find('.psu-box').post_selection_ui();
 		};
+
+	} else  {
+
+		$( document ).on( 'widget-added', function( e, $widget ) {
+
+			$psu = $widget.find( '.psu-box' );
+
+			$psu.length && $psu.post_selection_ui();
+
+		} );
+
 	}
+
 })(jQuery);


### PR DESCRIPTION
wpWidgets.fixLabels was removed in WP 3.9, hook into the new ‘widget-added’ event if fixLabels is undefined.
