### PR TITLE
refactor post-selection-ui to work with wp3.5-wp4.0

### DIFF
--- a/post-selection-ui.js
+++ b/post-selection-ui.js
@@ -296,36 +296,55 @@
 
 	}
 
+	// get wordpress version
+	var wpVersion = null;
+	if ( parseInt( PostSelectionUI.wpVersion ) === 4 ) {
+
+		wpVersion = 4;
+
+	} else {
+
+		var versionSplit = PostSelectionUI.wpVersion.split('.');
+		wpVersion = parseFloat( parseInt( versionSplit[0] ) + ( parseInt( versionSplit[1] ) / 10 ) );
+
+	}
+
 	//work around for first creation of widget
-	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.appendTitle ) ) {
+	if ( wpVersion >= 3.9 ) {
 
-		var oldAppendTitle = __bind(wpWidgets, wpWidgets.appendTitle);
+		$( document ).on( 'widget-added widget-updated', initPostSelectionUIOnEvent );
 
-		wpWidgets.appendTitle = function(widget) {
-			oldAppendTitle(widget);
-			if ( ( 'object' === typeof widget ) && ( 'function' === typeof widget.find ) ) {
-				initPostSelectionUIOnEvent( null, widget );
+	} else {
+
+		if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.appendTitle ) ) {
+
+				var oldAppendTitle = __bind(wpWidgets, wpWidgets.appendTitle);
+
+				wpWidgets.appendTitle = function(widget) {
+					oldAppendTitle(widget);
+					if ( ( 'object' === typeof widget ) && ( 'function' === typeof widget.find ) ) {
+						initPostSelectionUIOnEvent( null, widget );
+					}
+
+				};
+
 			}
 
-		};
+		//work around for rebuilding of widget
+		if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.save ) ) {
+
+			var oldSave = __bind(wpWidgets, wpWidgets.save);
+
+			wpWidgets.save = function (widget, del, animate, order) {
+				oldSave(widget, del, animate, order);
+				if (( 'object' === typeof widget ) && ( 'function' === typeof widget.find )) {
+					initPostSelectionUIOnEvent(null, widget);
+				}
+
+
+			};
+		}
 
 	}
-
-	//work around for rebuilding of widget
-	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.save ) ) {
-
-		var oldSave = __bind(wpWidgets, wpWidgets.save);
-
-		wpWidgets.save = function(widget, del, animate, order) {
-			oldSave(widget, del, animate, order);
-			if ( ( 'object' === typeof widget ) && ( 'function' === typeof widget.find ) ) {
-				initPostSelectionUIOnEvent( null, widget );
-			}
-
-
-		};
-
-	}
-	$( document ).on( 'widget-added widget-updated', initPostSelectionUIOnEvent );
 
 })(jQuery);

--- a/post-selection-ui.js
+++ b/post-selection-ui.js
@@ -297,22 +297,35 @@
 	}
 
 	//work around for first creation of widget
-	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.fixLabels ) ) {
+	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.appendTitle ) ) {
 
-		var oldSave = __bind(wpWidgets, wpWidgets.fixLabels);
+		var oldAppendTitle = __bind(wpWidgets, wpWidgets.appendTitle);
 
-		wpWidgets.fixLabels = function(widget) {
-			oldSave(widget);
-			if(typeof console != 'undefined'){
-				console.log(widget);
+		wpWidgets.appendTitle = function(widget) {
+			oldAppendTitle(widget);
+			if ( ( 'object' === typeof widget ) && ( 'function' === typeof widget.find ) ) {
+				initPostSelectionUIOnEvent( null, widget );
 			}
-			initPostSelectionUIOnEvent( null, widget );
+
 		};
 
-	} else  {
+	}
 
-		$( document ).on( 'widget-added widget-updated', initPostSelectionUIOnEvent );
+	//work around for rebuilding of widget
+	if ( ( 'object' === typeof wpWidgets ) && ( 'function' === typeof wpWidgets.save ) ) {
+
+		var oldSave = __bind(wpWidgets, wpWidgets.save);
+
+		wpWidgets.save = function(widget, del, animate, order) {
+			oldSave(widget, del, animate, order);
+			if ( ( 'object' === typeof widget ) && ( 'function' === typeof widget.find ) ) {
+				initPostSelectionUIOnEvent( null, widget );
+			}
+
+
+		};
 
 	}
+	$( document ).on( 'widget-added widget-updated', initPostSelectionUIOnEvent );
 
 })(jQuery);

--- a/post-selection-ui.php
+++ b/post-selection-ui.php
@@ -24,6 +24,7 @@ class Post_Selection_UI {
 			'nonce' => wp_create_nonce( 'psu_search' ),
 			'spinner' => admin_url( 'images/wpspin_light.gif' ),
 			'clearConfirmMessage' => __( 'Are you sure you want to clear the selected items?' ),
+			'wpVersion' => get_bloginfo( 'version' )
 		) );
 
 	}


### PR DESCRIPTION
- added monkeypatch for `wpWidgets.appendTitle` and `wpWidgets.save` to hook `initPostSelectionUIOnEvent` for all use cases for WordPress 3.5 - 4.0 (including 1. on page load, 2. adding a brand new widget when none exist yet and 3. when saving and re-rendering of post-selection-ui
- removed event bindings out of the `else` conditional. @jeffstieler one thing to note on this is that these event bindings are _not_ necessary to get this to work in WP 3.5 - 4.0, but I would venture to guess this would _help_ future compatibility (so long as the event emitters remain as is). Could you think of any reason why these would hurt to leave them in?
- removed the console debug statements
