### PR TITLE
allow setting of post_parent in args

### DIFF
--- a/post-selection-ui.php
+++ b/post-selection-ui.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Post Selection UI
 Description: An extraction of the post selection interface from the posts-to-posts plugin
-Version: 1.0.11
+Version: 1.0.12
 Author: prettyboymp, banderon, matstars
 Plugin URI: http://voceconnect.com
 


### PR DESCRIPTION
use case - i have a post type 'offering' in which I have a psu meta box in pages, only the top level offerings should be selected, it would not make sense to select a child. this will enable me to prevent user error (i.e. selecting a child offering)
