### PR TITLE
Moving height check to be in scroll event since the height can change…

### DIFF
--- a/post-selection-ui.js
+++ b/post-selection-ui.js
@@ -229,12 +229,11 @@
 				prototype.infinite_scroll =  function(page){
 					var	$box = this,
 						$this = this.tab,
-						updating = false,
-						height = $this.prop('scrollHeight') - $this.height()
+						updating = false
 					;
 					$this.scroll(function () {
 						var	scroll = $this.scrollTop(),
-							isScrolledToEnd = (scroll >= (height - 50))
+							isScrolledToEnd = (scroll >= ($this.prop('scrollHeight') - $this.height() - 50))
 						;
 
 						if (isScrolledToEnd && !updating) {


### PR DESCRIPTION
… if a post is selection. Previously the height variable would not update unless a new page was added, thus breaking the infinite scroll after a post is selected.